### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*.sw?
+.yardoc
+dist
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,52 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-  PuppetLint.configuration.send("disable_selector_inside_resource")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-postfix.spec
+++ b/build/pupmod-postfix.spec
@@ -1,12 +1,11 @@
 Summary: Postfix Puppet Module
 Name: pupmod-postfix
 Version: 4.1.0
-Release: 5
+Release: 6
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: pupmod-common >= 2.1.2-2
 Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-simpcat >= 2.0.0-0
 Requires: pupmod-iptables >= 2.0.0-0
@@ -62,8 +61,11 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Feb 16 2016 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-6
+- Removed common dependency (simplib takes care of it)
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-5
-- migration to simplib and simpcat (lib/ only)
+- Migration to simplib and simpcat (lib/ only)
 
 * Thu Feb 19 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-4
 - Migrated to the new 'simp' environment.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@
 class postfix (
   $enable_server = false
 ) {
+  validate_bool($enable_server)
 
   if $enable_server { include 'postfix::server' }
 
@@ -227,6 +228,4 @@ mailboxes `echo -n "+ "; find ~/Maildir -type d -name ".*" -printf "+\'%f\' "`
     shell      => '/sbin/nologin',
     require    => Package['postfix']
   }
-
-  validate_bool($enable_server)
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -70,6 +70,15 @@ class postfix::server (
   $mandatory_ciphers = 'high',
   $enable_simp_pki = true
 ) {
+  validate_array($inet_interfaces)
+  validate_bool($enable_iptables)
+  validate_net_list($client_nets)
+  validate_bool($enable_user_connect)
+  validate_bool($enable_tls)
+  validate_bool($enforce_tls)
+  validate_array_member($mandatory_ciphers,['export','low','medium','high','null'])
+  validate_bool($enable_simp_pki)
+
   include 'postfix'
 
   # Don't do any of this if we're just listening on localhost.
@@ -81,12 +90,14 @@ class postfix::server (
     if $enable_iptables {
       include 'iptables'
 
+      $_dports      = $enable_user_connect ? {
+        true    => ['25','587'],
+        default => '25'
+      }
+
       ::iptables::add_tcp_stateful_listen { 'allow_postfix':
         client_nets => $client_nets,
-        dports      => $enable_user_connect ? {
-          true    => ['25','587'],
-          default => '25'
-        }
+        dports      => $_dports
       }
     }
 
@@ -122,14 +133,5 @@ class postfix::server (
         }
       }
     }
-
-    validate_array($inet_interfaces)
-    validate_bool($enable_iptables)
-    validate_net_list($client_nets)
-    validate_bool($enable_user_connect)
-    validate_bool($enable_tls)
-    validate_bool($enforce_tls)
-    validate_array_member($mandatory_ciphers,['export','low','medium','high','null'])
-    validate_bool($enable_simp_pki)
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,45 @@
+{
+  "name":    "simp-postfix",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "A collection of common SIMP functions, facts, and types",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-postfix",
+  "project_page": "https://github.com/simp/pupmod-simp-postfix",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "postfix" ],
+  "dependencies": [
+    {
+      "name": "simp/iptables",
+      "version_requirement": ">= 2.0.0"
+    },
+    {
+      "name": "simp/rsync",
+      "version_requirement": ">= 2.0.0"
+    },
+    {
+      "name": "simp/simpcat",
+      "version_requirement": ">= 2.0.0"
+    },
+    {
+      "name": "simp/simplib",
+      "version_requirement": ">= 1.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'postfix' do
-  it { should create_class('postfix') }
+  it { is_expected.to create_class('postfix') }
 
   base_facts = {
     :operatingsystem => 'RedHat',
@@ -11,20 +11,20 @@ describe 'postfix' do
   let(:facts){base_facts}
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should contain_simp_file_line('/root/.bashrc') }
-    it { should contain_exec('postalias').that_requires('Package[postfix]') }
-    it { should contain_exec('postalias').that_subscribes_to('File[/etc/aliases]') }
-    it { should contain_file('/etc/aliases').that_subscribes_to('Concat_build[postfix]') }
-    it { should contain_package('postfix') }
-    it { should contain_package('mutt') }
-    it { should contain_user('postfix') }
-    it { should contain_file('/root/.muttrc').with({ 'replace' => false }) }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_simp_file_line('/root/.bashrc') }
+    it { is_expected.to contain_exec('postalias').that_requires('Package[postfix]') }
+    it { is_expected.to contain_exec('postalias').that_subscribes_to('File[/etc/aliases]') }
+    it { is_expected.to contain_file('/etc/aliases').that_subscribes_to('Concat_build[postfix]') }
+    it { is_expected.to contain_package('postfix') }
+    it { is_expected.to contain_package('mutt') }
+    it { is_expected.to contain_user('postfix') }
+    it { is_expected.to contain_file('/root/.muttrc').with({ 'replace' => false }) }
   end
 
   context 'with_server_enabled' do
     let(:params) {{ :enable_server => true }}
-    it {should create_class('postfix::server') }
-    it { should compile.with_all_deps }
+    it {is_expected.to create_class('postfix::server') }
+    it { is_expected.to compile.with_all_deps }
   end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -9,22 +9,22 @@ describe 'postfix::server' do
   }
   let(:facts){base_facts}
 
-  it { should create_class('postfix') }
-  it { should create_class('postfix::server') }
+  it { is_expected.to create_class('postfix') }
+  it { is_expected.to create_class('postfix::server') }
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_class('iptables') }
-    it { should create_class('pki') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_postfix').with
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('iptables') }
+    it { is_expected.to create_class('pki') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_postfix').with
       ({
         'dports' => ['25','587']
       })
     }
-    it { should create_postfix_main_cf('smtp_use_tls') }
-    it { should create_postfix_main_cf('smtp_enforce_tls') }
-    it { should create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
-    it { should contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
+    it { is_expected.to create_postfix_main_cf('smtp_use_tls') }
+    it { is_expected.to create_postfix_main_cf('smtp_enforce_tls') }
+    it { is_expected.to create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
+    it { is_expected.to contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
   end
 
   context 'mandatory_cipher_validation' do
@@ -32,7 +32,7 @@ describe 'postfix::server' do
     let(:params){{ :mandatory_ciphers => err }}
     it {
       expect {
-        should compile.with_all_deps
+        is_expected.to compile.with_all_deps
       }.to raise_error(/does not contain '#{err}'/)
     }
   end
@@ -40,71 +40,71 @@ describe 'postfix::server' do
   context 'just_localhost' do
     let(:params){{ :inet_interfaces => ['localhost'] }}
 
-    it { should compile.with_all_deps }
-    it { should_not create_class('iptables') }
-    it { should_not create_class('pki') }
-    it { should_not create_iptables__add_tcp_stateful_listen('allow_postfix') }
-    it { should_not create_postfix_main_cf('smtp_use_tls') }
-    it { should_not create_postfix_main_cf('smtp_enforce_tls') }
-    it { should_not create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
-    it { should_not contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to create_class('iptables') }
+    it { is_expected.not_to create_class('pki') }
+    it { is_expected.not_to create_iptables__add_tcp_stateful_listen('allow_postfix') }
+    it { is_expected.not_to create_postfix_main_cf('smtp_use_tls') }
+    it { is_expected.not_to create_postfix_main_cf('smtp_enforce_tls') }
+    it { is_expected.not_to create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
+    it { is_expected.not_to contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
   end
 
   context 'no_iptables' do
     let(:params){{ :enable_iptables => false }}
 
-    it { should compile.with_all_deps }
-    it { should_not create_class('iptables') }
-    it { should create_class('pki') }
-    it { should_not create_iptables__add_tcp_stateful_listen('allow_postfix') }
-    it { should create_postfix_main_cf('smtp_use_tls') }
-    it { should create_postfix_main_cf('smtp_enforce_tls') }
-    it { should create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
-    it { should contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to create_class('iptables') }
+    it { is_expected.to create_class('pki') }
+    it { is_expected.not_to create_iptables__add_tcp_stateful_listen('allow_postfix') }
+    it { is_expected.to create_postfix_main_cf('smtp_use_tls') }
+    it { is_expected.to create_postfix_main_cf('smtp_enforce_tls') }
+    it { is_expected.to create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
+    it { is_expected.to contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
   end
 
   context 'no_enable_user_connect' do
     let(:params){{ :enable_user_connect => false }}
 
-    it { should create_iptables__add_tcp_stateful_listen('allow_postfix').with({ 'dports' => '25' }) }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_postfix').with({ 'dports' => '25' }) }
   end
 
   context 'no_enable_tls' do
     let(:params){{ :enable_tls => false }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('iptables') }
-    it { should_not create_class('pki') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_postfix') }
-    it { should_not create_postfix_main_cf('smtp_use_tls') }
-    it { should_not create_postfix_main_cf('smtp_enforce_tls') }
-    it { should_not create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
-    it { should_not contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('iptables') }
+    it { is_expected.not_to create_class('pki') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_postfix') }
+    it { is_expected.not_to create_postfix_main_cf('smtp_use_tls') }
+    it { is_expected.not_to create_postfix_main_cf('smtp_enforce_tls') }
+    it { is_expected.not_to create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
+    it { is_expected.not_to contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
   end
 
   context 'no_enforce_tls' do
     let(:params){{ :enforce_tls => false }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('iptables') }
-    it { should create_class('pki') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_postfix') }
-    it { should create_postfix_main_cf('smtp_use_tls') }
-    it { should_not create_postfix_main_cf('smtp_enforce_tls') }
-    it { should create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
-    it { should contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('iptables') }
+    it { is_expected.to create_class('pki') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_postfix') }
+    it { is_expected.to create_postfix_main_cf('smtp_use_tls') }
+    it { is_expected.not_to create_postfix_main_cf('smtp_enforce_tls') }
+    it { is_expected.to create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
+    it { is_expected.to contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
   end
 
   context 'no_enable_simp_pki' do
     let(:params){{ :enable_simp_pki => false }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('iptables') }
-    it { should_not create_class('pki') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_postfix') }
-    it { should create_postfix_main_cf('smtp_use_tls') }
-    it { should create_postfix_main_cf('smtp_enforce_tls') }
-    it { should create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
-    it { should_not contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('iptables') }
+    it { is_expected.not_to create_class('pki') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_postfix') }
+    it { is_expected.to create_postfix_main_cf('smtp_use_tls') }
+    it { is_expected.to create_postfix_main_cf('smtp_enforce_tls') }
+    it { is_expected.to create_postfix_main_cf('smtp_tls_mandatory_ciphers').with({ 'value' => 'high' }) }
+    it { is_expected.not_to contain_pki__copy('/etc/postfix').that_notifies('Service[postfix]') }
   end
 end

--- a/spec/defines/alias_spec.rb
+++ b/spec/defines/alias_spec.rb
@@ -5,7 +5,7 @@ describe 'postfix::alias' do
   let(:params) {{ :values => 'test test' }}
 
   it do
-    should contain_concat_fragment("postfix+#{title}.alias").with({
+    is_expected.to contain_concat_fragment("postfix+#{title}.alias").with({
       'content' => "#{title}: #{params[:values]}\n"
     })
   end

--- a/spec/unit/puppet/provider/postfix_main_cf/ruby_spec.rb
+++ b/spec/unit/puppet/provider/postfix_main_cf/ruby_spec.rb
@@ -11,12 +11,12 @@ describe provider_class do
   context "when matching" do
     it 'should do nothing if the postconf command returns a matching value' do
       @provider.stubs(:postconf).with('mail_owner').returns "mail_owner = postfix\n"
-      @provider.value.should == 'postfix'
+      expect(@provider.value).to eq('postfix')
     end
 
     it 'should return an error if the postconf command returns an invalid result' do
       @provider.stubs(:postconf).with('mail_owner').returns "unknown entry\n"
-      expect { @provider.value.should }.to raise_error(Puppet::Error,/not recognized by postconf/)
+      expect { expect(@provider.value).to }.to raise_error(Puppet::Error,/not recognized by postconf/)
     end
 
     it 'should attempt an update if the postconf command returns a non-matching value' do

--- a/spec/unit/puppet/type/postfix_main_cf_spec.rb
+++ b/spec/unit/puppet/type/postfix_main_cf_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Type.type(:postfix_main_cf) do
   end
 
   it 'should notify Service[postfix]' do
-    postfix_main_cf[:notify].map{|x| x = x.to_s}.should include('Service[postfix]')
+    expect(postfix_main_cf[:notify].map{|x| x = x.to_s}).to include('Service[postfix]')
   end
 
   it 'should notify Service[postfix] if passed another notify parameter' do
@@ -29,6 +29,6 @@ describe Puppet::Type.type(:postfix_main_cf) do
       :notify => 'Service[test]'
     )
 
-    postfix_main_cf[:notify].map{|x| x = x.to_s}.should include('Service[postfix]')
+    expect(postfix_main_cf[:notify].map{|x| x = x.to_s}).to include('Service[postfix]')
   end
 end


### PR DESCRIPTION
This commit synchronizes all common static module assets with current SIMP
module standards.

Also:
- updated rspec tests to the new `expect` syntax
- moved validations to the tops of classes
- bumped RPM version to 4.1.0-6
- created .puppet-lint.rc, .travis.yml, .gitignore, Gemfile

SIMP-667 #comment updated `pupmod-simp-postfix`
SIMP-750 #close #comment normalized common module assets
