### PR TITLE
(SIMP-1574) Fix Forge `haveged` dependency name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.4-0
+- Fix Forge `haveged` dependency name
+
 * Mon Jul 11 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.3-0
 - Migration to semantic versioning and fix of the build system
 - Added basic acceptance tests

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,19 @@
 {
-  "name":    "simp-postfix",
-  "version": "4.1.3",
-  "author":  "simp",
+  "name": "simp-postfix",
+  "version": "4.1.4",
+  "author": "simp",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-postfix",
+  "source": "https://github.com/simp/pupmod-simp-postfix",
   "project_page": "https://github.com/simp/pupmod-simp-postfix",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "postfix" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "postfix"
+  ],
   "dependencies": [
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
`metadata.json` erroneously claimed `simp/puppet-haveged` as a
dependency, which causes a fatal error when pushing to the Forge.

This patch corrects the dependency name  to `simp/haveged`.

SIMP-1574 #comment fixed pupmod-simp-postfix