### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.4-0
 - Fix Forge `haveged` dependency name
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -2,5 +2,5 @@ Requires: pupmod-simp-compliance_markup
 Requires: pupmod-simp-haveged >= 0.3.0
 Requires: pupmod-simp-iptables >= 2.0.0-0
 Requires: pupmod-simp-rsync >= 2.0.0-0
-Requires: pupmod-simp-simpcat >= 2.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-postfix-test >= 0.0.1

--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -21,7 +21,7 @@
 define postfix::alias (
     $values
   ){
-  concat_fragment { "postfix+${name}.alias":
+  simpcat_fragment { "postfix+${name}.alias":
     content => "${name}: ${values}\n"
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,12 +36,12 @@ class postfix (
     require     => Package['postfix']
   }
 
-  concat_build { 'postfix':
+  simpcat_build { 'postfix':
     order  => ['*.alias'],
     target => '/etc/aliases'
   }
 
-  concat_fragment { 'postfix+0.alias':
+  simpcat_fragment { 'postfix+0.alias':
     content => template('postfix/aliases.erb')
   }
 
@@ -79,7 +79,7 @@ class postfix (
     group     => 'root',
     mode      => '0644',
     require   => Package['postfix'],
-    subscribe => Concat_build['postfix'],
+    subscribe => Simpcat_build['postfix'],
     audit     => content
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-postfix",
-  "version": "4.1.4",
+  "version": "5.0.0",
   "author": "simp",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",
@@ -26,7 +26,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,7 @@ describe 'postfix' do
         it { is_expected.to contain_simp_file_line('/root/.bashrc') }
         it { is_expected.to contain_exec('postalias').that_requires('Package[postfix]') }
         it { is_expected.to contain_exec('postalias').that_subscribes_to('File[/etc/aliases]') }
-        it { is_expected.to contain_file('/etc/aliases').that_subscribes_to('Concat_build[postfix]') }
+        it { is_expected.to contain_file('/etc/aliases').that_subscribes_to('Simpcat_build[postfix]') }
         it { is_expected.to contain_package('postfix') }
         it { is_expected.to contain_package('mutt') }
         it { is_expected.to contain_user('postfix') }

--- a/spec/defines/alias_spec.rb
+++ b/spec/defines/alias_spec.rb
@@ -5,7 +5,7 @@ describe 'postfix::alias' do
   let(:params) {{ :values => 'test test' }}
 
   it do
-    is_expected.to contain_concat_fragment("postfix+#{title}.alias").with({
+    is_expected.to contain_simpcat_fragment("postfix+#{title}.alias").with({
       'content' => "#{title}: #{params[:values]}\n"
     })
   end


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'postfix'
