### PR TITLE
(SIMP-1677) Remove deprecated Puppet.newtype

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Nov 10 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.6-0
+- Eliminated use of deprecated Puppet.newtype
+
 * Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.4-0
 - Fix Forge `haveged` dependency name
 

--- a/lib/puppet/type/postfix_main_cf.rb
+++ b/lib/puppet/type/postfix_main_cf.rb
@@ -1,37 +1,35 @@
-module Puppet
-  newtype(:postfix_main_cf) do
-    require 'puppet/util/selinux'
-    include Puppet::Util::SELinux
+Puppet::Type.newtype(:postfix_main_cf) do
+  require 'puppet/util/selinux'
+  include Puppet::Util::SELinux
 
-    @doc = "Modifies settings in the postfix main.cf configuration file."
+  @doc = "Modifies settings in the postfix main.cf configuration file."
 
-    def initialize(args)
-      super(args)
+  def initialize(args)
+    super(args)
 
-      if self[:notify] then
-        self[:notify] += ['Service[postfix]']
-      else
-        self[:notify] = ['Service[postfix]']
-      end
+    if self[:notify] then
+      self[:notify] += ['Service[postfix]']
+    else
+      self[:notify] = ['Service[postfix]']
     end
-    newparam(:name) do
-      isnamevar
-      desc "The parameter to modify."
+  end
+  newparam(:name) do
+    isnamevar
+    desc "The parameter to modify."
+  end
+
+  newproperty(:value) do
+    desc "The value to which to set the named parameter."
+  end
+
+  validate do
+    must_supply = [:value]
+
+    found = true
+    must_supply.each do |var|
+      not self[var] or self[var].empty? and found = false and break
     end
 
-    newproperty(:value) do
-      desc "The value to which to set the named parameter."
-    end
-
-    validate do
-      must_supply = [:value]
-
-      found = true
-      must_supply.each do |var|
-        not self[var] or self[var].empty? and found = false and break
-      end
-
-      raise(ArgumentError,"You must supply all of '#{must_supply.join(', ')}'") if not found
-    end
+    raise(ArgumentError,"You must supply all of '#{must_supply.join(', ')}'") if not found
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-postfix",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "author": "simp",
   "summary": "Manages the Postfix mail server",
   "license": "Apache-2.0",


### PR DESCRIPTION
Eliminated use of deprecated Puppet.newtype

SIMP-1899 #close