### PR TITLE
(SIMP-1677) Remove deprecated Puppet.newtype

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,12 +8,17 @@ fixtures:
     augeasproviders_grub:
       repo: "https://github.com/simp/augeasproviders_grub"
       branch: "simp-master"
-    compliance_markup: "https://github.com/simp/pupmod-simp-compliance_markup"
+    compliance_markup:
+      repo: "https://github.com/simp/pupmod-simp-compliance_markup"
+      branch: "master"
+#      branch: "1.0.2"
     haveged:
       repo: "https://github.com/simp/puppet-haveged"
       branch: "simp-master"
     iptables: "https://github.com/simp/pupmod-simp-iptables"
+    logrotate: "https://github.com/simp/pupmod-simp-logrotate"
     pki: "https://github.com/simp/pupmod-simp-pki"
+    rsyslog: "https://github.com/simp/pupmod-simp-rsyslog"
     simpcat: "https://github.com/simp/pupmod-simp-simpcat"
     simplib: "https://github.com/simp/pupmod-simp-simplib"
     stdlib:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-0
+* Thu Nov 10 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
+- Eliminated use of deprecated Puppet.newtype
+- Updated to compliance_markup version 2
+
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
 - Updated to use the version of 'simpcat' that does not conflict with
   'puppetlabs/concat'.
 

--- a/lib/puppet/type/postfix_main_cf.rb
+++ b/lib/puppet/type/postfix_main_cf.rb
@@ -1,37 +1,35 @@
-module Puppet
-  newtype(:postfix_main_cf) do
-    require 'puppet/util/selinux'
-    include Puppet::Util::SELinux
+Puppet::Type.newtype(:postfix_main_cf) do
+  require 'puppet/util/selinux'
+  include Puppet::Util::SELinux
 
-    @doc = "Modifies settings in the postfix main.cf configuration file."
+  @doc = "Modifies settings in the postfix main.cf configuration file."
 
-    def initialize(args)
-      super(args)
+  def initialize(args)
+    super(args)
 
-      if self[:notify] then
-        self[:notify] += ['Service[postfix]']
-      else
-        self[:notify] = ['Service[postfix]']
-      end
+    if self[:notify] then
+      self[:notify] += ['Service[postfix]']
+    else
+      self[:notify] = ['Service[postfix]']
     end
-    newparam(:name) do
-      isnamevar
-      desc "The parameter to modify."
+  end
+  newparam(:name) do
+    isnamevar
+    desc "The parameter to modify."
+  end
+
+  newproperty(:value) do
+    desc "The value to which to set the named parameter."
+  end
+
+  validate do
+    must_supply = [:value]
+
+    found = true
+    must_supply.each do |var|
+      not self[var] or self[var].empty? and found = false and break
     end
 
-    newproperty(:value) do
-      desc "The value to which to set the named parameter."
-    end
-
-    validate do
-      must_supply = [:value]
-
-      found = true
-      must_supply.each do |var|
-        not self[var] or self[var].empty? and found = false and break
-      end
-
-      raise(ArgumentError,"You must supply all of '#{must_supply.join(', ')}'") if not found
-    end
+    raise(ArgumentError,"You must supply all of '#{must_supply.join(', ')}'") if not found
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,6 @@ class postfix (
   $enable_server = false
 ) {
   validate_bool($enable_server)
-  compliance_map()
 
   if $enable_server { include 'postfix::server' }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -86,8 +86,6 @@ class postfix::server (
   validate_bool($enable_simp_pki)
   validate_bool($use_haveged)
 
-  compliance_map()
-
   include 'postfix'
 
   # Don't do any of this if we're just listening on localhost.

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.2 < 2.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Eliminated use of deprecated Puppet.newtype
- Updated to compliance_markup version 2

SIMP-1888 #close