### PR TITLE
(SIMP-223) Update for SIMP 6 Rsync

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -3,8 +3,6 @@ Requires: pupmod-simp-haveged < 1.0.0-0
 Requires: pupmod-simp-haveged >= 0.3.2-0
 Requires: pupmod-simp-iptables < 6.0.0-0
 Requires: pupmod-simp-iptables >= 5.0.0-0
-Requires: pupmod-simp-rsync < 6.0.0-0
-Requires: pupmod-simp-rsync >= 5.0.0-0
 Requires: pupmod-simp-simpcat < 7.0.0-0
 Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-simplib < 3.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-postfix",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "Manages the Postfix mail server",
   "license": "Apache-2.0",
@@ -21,10 +21,6 @@
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
-    },
-    {
-      "name": "simp/rsync",
       "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {


### PR DESCRIPTION
Removed incorrect dependency on Rsync found when testing SIMP 6 rsync
changes.

SIMP-223 #comment Removed incorrect rsync dependency