### PR TITLE
(SIMP-3175) Remove `audit` metaparameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri May 19 2017 Nick Miller <nick.miller@onyxpoint.com> - 5.0.2-0
+- Removed `audit` metaparameter
+- Implemented `package_ensure` catalyst
+- Cleaned up some code formatting
+
 * Tue Jan 10 2017 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.1-0
 - Updated the pki scheme
 - Application certs now managed in /etc/pki/simp_apps/postfix/x509

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -6,6 +6,6 @@ Requires: pupmod-simp-iptables >= 6.0.0-0
 Requires: pupmod-simp-simpcat < 7.0.0-0
 Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-simplib < 4.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0
+Requires: pupmod-simp-simplib >= 3.4.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,8 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class postfix (
-  Boolean $enable_server = false
+  Boolean $enable_server = false,
+  Simplib::PackageEnsure $ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
 
   if $enable_server { include 'postfix::server' }
@@ -42,14 +43,15 @@ class postfix (
     require => Package['postfix']
   }
 
-  file { [
-    '/etc/postfix/postfix-script',
-    '/etc/postfix/post-install'
-  ]:
-    owner   => 'root',
-    group   => 'postfix',
-    mode    => '0750',
-    require => Package['postfix']
+  file {
+    default:
+      owner   => 'root',
+      group   => 'postfix',
+      mode    => '0750',
+      require => Package['postfix'];
+
+    '/etc/postfix/postfix-script':;
+    '/etc/postfix/post-install':;
   }
 
   #---
@@ -69,8 +71,7 @@ class postfix (
     group     => 'root',
     mode      => '0644',
     require   => Package['postfix'],
-    subscribe => Simpcat_build['postfix'],
-    audit     => content
+    subscribe => Simpcat_build['postfix']
   }
 
   # Main configuration file
@@ -79,7 +80,6 @@ class postfix (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    audit   => 'content',
     notify  => Service['postfix'],
     require => Package['postfix']
   }
@@ -90,46 +90,45 @@ class postfix (
     group   => 'root',
     mode    => '0640',
     #content => template('postfix/master.cf.erb'),
-    audit   => 'content',
     notify  => Service['postfix'],
     require => Package['postfix']
   }
 
   # postmap files.
-  file { [
-          '/etc/postfix/access',
-          '/etc/postfix/canonical',
-          '/etc/postfix/generic',
-          '/etc/postfix/relocated',
-          '/etc/postfix/transport',
-          '/etc/postfix/virtual'
-  ]:
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0640',
-    #content => template('postfix/postmap.erb'),
-    audit   => 'content',
-    require => Package['postfix'],
-    #notify => Exec['postmap']
+  file {
+    default:
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0640',
+      #content => template('postfix/postmap.erb'),
+      require => Package['postfix'];
+      #notify => Exec['postmap']
+
+    '/etc/postfix/access':;
+    '/etc/postfix/canonical':;
+    '/etc/postfix/generic':;
+    '/etc/postfix/relocated':;
+    '/etc/postfix/transport':;
+    '/etc/postfix/virtual':;
   }
 
   # Content checks
   # These need defines to add stuff to them.
-  file { [
-          '/etc/postfix/header_checks',
-          '/etc/postfix/mime_header_checks',
-          '/etc/postfix/nested_header_checks',
-          '/etc/postfix/body_checks'
-  ]:
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0640',
-    #content => template('postfix/checks.erb'),
-    audit   => 'content',
-    notify  => Service['postfix'],
-    require => Package['postfix']
+  file {
+    default:
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0640',
+      #content => template('postfix/checks.erb'),
+      notify  => Service['postfix'],
+      require => Package['postfix'];
+
+    '/etc/postfix/header_checks':;
+    '/etc/postfix/mime_header_checks':;
+    '/etc/postfix/nested_header_checks':;
+    '/etc/postfix/body_checks':;
   }
 
   file { '/usr/libexec/postfix':
@@ -198,9 +197,8 @@ mailboxes `echo -n "+ "; find ~/Maildir -type d -name ".*" -printf "+\'%f\' "`
     require   => Package['postfix']
   }
 
-  package { 'postfix': ensure => 'latest' }
-
-  package { 'mutt': ensure => 'latest' }
+  package { 'postfix': ensure => $ensure }
+  package { 'mutt': ensure => $ensure }
 
   service { 'postfix':
     ensure     => 'running',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,11 +4,16 @@
 # @param enable_server
 #   Whether or not to enable the *externally facing* server.
 #
+# @param postfix_ensure String to pass to the `postfix` package ensure attribute
+#
+# @param mutt_ensure String to pass to the `mutt` package ensure attribute
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class postfix (
   Boolean $enable_server = false,
-  Simplib::PackageEnsure $ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  String $postfix_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  String $mutt_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
 
   if $enable_server { include 'postfix::server' }
@@ -197,8 +202,8 @@ mailboxes `echo -n "+ "; find ~/Maildir -type d -name ".*" -printf "+\'%f\' "`
     require   => Package['postfix']
   }
 
-  package { 'postfix': ensure => $ensure }
-  package { 'mutt': ensure => $ensure }
+  package { 'postfix': ensure => $postfix_ensure }
+  package { 'mutt': ensure => $mutt_ensure }
 
   service { 'postfix':
     ensure     => 'running',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -70,20 +70,20 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class postfix::server (
-  Array[String]                  $inet_interfaces         = ['all'],
-  Boolean                        $firewall                = simplib::lookup('simp_options::firewall', { 'default_value'     => false }),
-  Simplib::Netlist               $trusted_nets            = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
-  Boolean                        $enable_user_connect     = true,
-  Boolean                        $enable_tls              = true,
-  Boolean                        $enforce_tls             = true,
-  Postfix::ManCiphers            $mandatory_ciphers       = 'high',
-  Boolean                        $haveged                 = simplib::lookup('simp_options::haveged', { 'default_value'      => false }),
-  Variant[Enum['simp'],Boolean]  $pki                     = simplib::lookup('simp_options::pki', { 'default_value'          => false }),
-  Stdlib::Absolutepath           $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value'  => '/etc/pki/simp/x509' }),
-  Stdlib::Absolutepath           $app_pki_dir             = '/etc/pki/simp_apps/postfix/x509',
-  Stdlib::Absolutepath           $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",
-  Stdlib::Absolutepath           $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",
-  Stdlib::Absolutepath           $app_pki_ca_dir          = "${app_pki_dir}/cacerts"
+  Array[String]                 $inet_interfaces         = ['all'],
+  Boolean                       $firewall                = simplib::lookup('simp_options::firewall', { 'default_value'     => false }),
+  Simplib::Netlist              $trusted_nets            = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
+  Boolean                       $enable_user_connect     = true,
+  Boolean                       $enable_tls              = true,
+  Boolean                       $enforce_tls             = true,
+  Postfix::ManCiphers           $mandatory_ciphers       = 'high',
+  Boolean                       $haveged                 = simplib::lookup('simp_options::haveged', { 'default_value'      => false }),
+  Variant[Enum['simp'],Boolean] $pki                     = simplib::lookup('simp_options::pki', { 'default_value'          => false }),
+  Stdlib::Absolutepath          $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value'  => '/etc/pki/simp/x509' }),
+  Stdlib::Absolutepath          $app_pki_dir             = '/etc/pki/simp_apps/postfix/x509',
+  Stdlib::Absolutepath          $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",
+  Stdlib::Absolutepath          $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",
+  Stdlib::Absolutepath          $app_pki_ca_dir          = "${app_pki_dir}/cacerts"
 ) {
   validate_net_list($trusted_nets)
 
@@ -112,24 +112,16 @@ class postfix::server (
     if $enable_tls {
       if $haveged { include '::haveged' }
 
-      postfix_main_cf { 'smtp_use_tls': value => 'yes' }
-
       if $enforce_tls {
         postfix_main_cf { 'smtp_enforce_tls': value => 'yes' }
       }
 
-      postfix_main_cf { 'smtp_tls_mandatory_ciphers': value => $mandatory_ciphers }
-
-      postfix_main_cf { 'smtp_tls_CApath':
-        value   => $app_pki_ca_dir,
-      }
-
-      postfix_main_cf { 'smtp_tls_cert_file':
-        value   => $app_pki_cert,
-      }
-
-      postfix_main_cf { 'smtp_tls_key_file':
-        value   => $app_pki_key,
+      postfix_main_cf {
+        'smtp_use_tls'               : value => 'yes';
+        'smtp_tls_mandatory_ciphers' : value => $mandatory_ciphers;
+        'smtp_tls_CApath'            : value => $app_pki_ca_dir;
+        'smtp_tls_cert_file'         : value => $app_pki_cert;
+        'smtp_tls_key_file'          : value => $app_pki_key;
       }
 
       if $pki {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-postfix",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": "SIMP Team",
   "summary": "Manages the Postfix mail server",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.4.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -55,12 +55,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.2.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
- Removed deprecated `audit` metaparameter
- Implemented `package_ensure` catalyst
- Cleaned up some code formatting

SIMP-3175 #close