### PR TITLE
(SIMP-4692) Avoid deviating from RPM perms

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Jun 19 2018 Nick Miller <nick.miller@onyxpoint.com> - 5.1.0-0
+- Avoid changing the permissions from the vendored RPM
+  - /etc/postfix/* perms from 0640 to 0644
+  - /usr/libexec/postfix management is no longer recursive
+  - /var/spool/mail perms from 0755 to 0775
+
 * Thu May 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.1.0-0
 - Added main_cf_hash parameter so a list of additional settings for main.cf
   file can be added without the need for entering a resource for each one.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,17 +31,17 @@ class postfix::config {
     mode  => '0750';
   }
 
+
   #---
   # Files to be templated. Templates are commented.
   #+++
-
 
   # master daemon configuration file
   file { '/etc/postfix/master.cf':
     ensure => 'file',
     owner  => 'root',
     group  => 'root',
-    mode   => '0640',
+    mode   => '0644',
     #content => template('postfix/master.cf.erb'),
   }
 
@@ -57,7 +57,7 @@ class postfix::config {
     ensure => 'file',
     owner  => 'root',
     group  => 'root',
-    mode   => '0640';
+    mode   => '0644';
     #content => template('postfix/postmap.erb'),
     #notify => Exec['postmap']
   }
@@ -73,13 +73,12 @@ class postfix::config {
     ensure => 'file',
     owner  => 'root',
     group  => 'root',
-    mode   => '0640',
+    mode   => '0644',
     #content => template('postfix/checks.erb'),
   }
 
   file { '/usr/libexec/postfix':
-    ensure  => 'present',
-    recurse => true,
+    ensure  => 'directory',
     owner   => 'root',
     group   => 'root',
     mode    => '0755'
@@ -96,7 +95,7 @@ class postfix::config {
     ensure => 'directory',
     owner  => 'root',
     group  => 'mail',
-    mode   => '0755'
+    mode   => '0775'
   }
 
   file { '/var/mail':


### PR DESCRIPTION
- Avoid changing the permissions from the vendored RPM
  - /etc/postfix/* perms from 0640 to 0644
  - /usr/libexec/postfix management is no longer recursive
  - /var/spool/mail perms from 0755 to 0775

SIMP-4692 #comment postfix fixed