### PR TITLE
(SIMP-5303) updated $app_pki_external_source type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 5.1.1-0
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Mon Jul 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.1-0
 - Ensure that only IPv4 is used if IPv6 is disabled on the system
 - Add support for OEL and Puppet 5

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -79,7 +79,7 @@ class postfix::server (
   Postfix::ManCiphers           $mandatory_ciphers       = 'high',
   Boolean                       $haveged                 = simplib::lookup('simp_options::haveged', { 'default_value'      => false }),
   Variant[Enum['simp'],Boolean] $pki                     = simplib::lookup('simp_options::pki', { 'default_value'          => false }),
-  Stdlib::Absolutepath          $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value'  => '/etc/pki/simp/x509' }),
+  String                        $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value'  => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath          $app_pki_dir             = '/etc/pki/simp_apps/postfix/x509',
   Stdlib::Absolutepath          $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",
   Stdlib::Absolutepath          $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated simp_postfix
SIMP-5303 #close