### PR TITLE
(SIMP-6213) Allow latest concat

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.2.1-0
+- Expanded the upper limit of the concat and stdlib Puppet module versions
+- Updated a URL in the README.md
+
 * Wed Feb 13 2019 Chris Tessmer <chris.tessmer@onypoint.com> -5.2.1-0
 - Fix DOS formatting of CHANGELOG
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ## Work in Progress
 

--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
       "name": "simp/simplib",
@@ -33,7 +33,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Expanded the upper limit of the concat and stdlib Puppet module versions
- Updated a URL in the README.md

SIMP-6213 #comment pupmod-simp-postfix