### PR TITLE
(SIMP-6215) Fix "unrecognized escape `\''" error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Mar 05 2019 Chris Tessmer <chris.tessmer@onypoint.com> - 5.2.2-0
+- Fixed "unrecognized escape `\''" error in /root/.muttrc
+
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.2.1-0
 - Expanded the upper limit of the concat and stdlib Puppet module versions
 - Updated a URL in the README.md

--- a/manifests/config/root.pp
+++ b/manifests/config/root.pp
@@ -19,7 +19,7 @@ class postfix::config::root {
     set record="+.Sent"
     set postponed="+.Drafts"
     set spoolfile="/var/spool/mail/root"
-    mailboxes `echo -n "+ "; find ~/Maildir -type d -name ".*" -printf "+\'%f\' "`
+    mailboxes `echo -n "+ "; find ~/Maildir -type d -name ".*" -printf "+'%f' "`
     | MUTTRC
 
   file { '/root/.muttrc':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-postfix",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "author": "SIMP Team",
   "summary": "Manages the Postfix mail server",
   "license": "Apache-2.0",


### PR DESCRIPTION
SIMP-6215 #close