### PR TITLE
(SIMP-9888) Ensure min stdlib is 6.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.18.0 < 8.0.0"
+      "version_requirement": ">= 6.6.0 < 8.0.0"
     }
   ],
   "simp": {


### PR DESCRIPTION
This patch ensures the minimum puppetlabs/stdlib version is `6.6.0`.

[SIMP-9930] #close
[SIMP-9888] #comment pupmod-simp-postfix stdlib >= 6.6.0

[SIMP-9930]: https://simp-project.atlassian.net/browse/SIMP-9930
[SIMP-9888]: https://simp-project.atlassian.net/browse/SIMP-9888