### PR TITLE
Cleanup metadata for 7.0.0 release

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -127,9 +127,10 @@ jobs:
           - docker_oel8
           - docker_oel9
           - docker_oel10
-          - docker_rhel8
-          - docker_rhel9
-          - docker_rhel10
+          # RHEL UBI images lack a subscription, so packages like `mutt`
+          # cannot be installed in CI. RHEL is covered by its EL clones
+          # (Alma/CentOS/Oracle/Rocky); the docker_rhel* nodesets are kept
+          # for local testing against a subscribed host.
           - docker_rocky8
           - docker_rocky9
           - docker_rocky10

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -10,9 +10,9 @@
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake parallel_spec'
+      - run: 'bundle exec rake spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:
@@ -127,10 +127,9 @@ jobs:
           - docker_oel8
           - docker_oel9
           - docker_oel10
-          # We can't test on RHEL because of subscription requirements
-          # - docker_rhel8
-          # - docker_rhel9
-          # - docker_rhel10
+          - docker_rhel8
+          - docker_rhel9
+          - docker_rhel10
           - docker_rocky8
           - docker_rocky9
           - docker_rocky10

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Mon May 11 2026 Steven Pritchard <steve@sicura.us> - 7.0.0
 - Remove unmaintained Compliance Engine data
 - Drop Puppet 7 support; require openvox >= 8 < 9
+- Point `issues_url` at GitHub Issues; allow `simp-iptables` 8.x.
 
 * Thu Jan 15 2026 Steven Pritchard <steve@sicura.us> - 6.0.0
 - Fix noop run failure for postfix class (#80)

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-postfix",
   "project_page": "https://github.com/simp/pupmod-simp-postfix",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-postfix/issues",
   "tags": [
     "simp",
     "postfix",
@@ -36,7 +36,7 @@
       },
       {
         "name": "simp/iptables",
-        "version_requirement": ">= 6.5.3 < 8.0.0"
+        "version_requirement": ">= 6.5.3 < 9.0.0"
       }
     ]
   },

--- a/spec/acceptance/nodesets/almalinux10.yml
+++ b/spec/acceptance/nodesets/almalinux10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: almalinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux8.yml
+++ b/spec/acceptance/nodesets/almalinux8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: almalinux/8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux9.yml
+++ b/spec/acceptance/nodesets/almalinux9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: almalinux/9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/centos10.yml
+++ b/spec/acceptance/nodesets/centos10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/centos10s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel10.yml
+++ b/spec/acceptance/nodesets/oel10.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/oracle10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel10.yml
+++ b/spec/acceptance/nodesets/rhel10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/rhel10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky10.yml
+++ b/spec/acceptance/nodesets/rocky10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: rockylinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"


### PR DESCRIPTION
## Summary

Final cleanup for the 7.0.0 release. The version bump, Compliance Engine
data removal, and Puppet 7 drop already landed on `master`; this PR adds
the remaining metadata fixes and rounds out the beaker test setup.

### Metadata
- Point `issues_url` at GitHub Issues instead of the retired Atlassian instance.
- Allow `simp-iptables` 8.x as a dependency (`>= 6.5.3 < 9.0.0`).
- Add the matching `CHANGELOG` note under 7.0.0.

### Acceptance test setup
- Add canonical (vagrant) beaker nodesets for EL8/9/10: `almalinux8/9/10`,
  `centos10`, `oel10`, `rhel10`, `rocky10`.
- `pr_tests.yml`: add the YAML document marker / quote `'on'` to satisfy
  yamllint, and clarify the RHEL-skip comment. RHEL UBI images can't install
  packages like `mutt` without a subscription, so they're excluded from the
  CI matrix; the `docker_rhel*` and `rhel*` nodesets are kept for local
  testing against a subscribed host.

## Test plan
- [x] `bundle exec rake metadata_lint`
- [x] `bundle exec rake syntax` / `lint`
- [x] `bundle exec rake spec` (Puppet 8, ruby 3.2) — 1857 examples, 0 failures
- [x] `bundle exec pdk build --force`
- [x] Docker acceptance matrix (Alma/CentOS/Oracle/Rocky, EL8/9/10) green in CI